### PR TITLE
Solves kata 9 - DELETE /api/comments/comment_id

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -259,3 +259,31 @@ describe('PATCH /api/articles/:article_id', () => {
         })
     })
 })
+
+describe('DELETE /api/comments/:comment_id', () => {
+    test('Responds with a 204 confirming comment has been deleted', () => {
+        return request(app)
+        .delete('/api/comments/5')
+        .expect(204)
+        .then((response) => {
+            expect(response.body).toEqual({})
+        })
+    })
+    test('Responds with a 404 if the comment does not exist', () => {
+        return request(app)
+        .delete('/api/comments/999999')
+        .expect(404)
+        .then(({body}) => {
+            expect(body.error.message).toBe('No comment found')
+        })
+    })
+    test('Responds with a 400 if the comment id type is invalid', () => {
+        return request(app)
+        .delete('/api/comments/eight')
+        .expect(400)
+        .then(({body}) => {
+            expect(body.error.message).toBe('Bad Request: Invalid comment id')
+        })
+    })
+})
+

--- a/app/app.js
+++ b/app/app.js
@@ -1,6 +1,6 @@
 const express = require('express')
 
-const {getTopics, getApis, getArticleById, getArticles, getComments, addComment, updateArticleById} = require('./controllers/controller')
+const {getTopics, getApis, getArticleById, getArticles, getComments, addComment, updateArticleById, deleteComment} = require('./controllers/controller')
 
 const app = express()
 
@@ -20,6 +20,7 @@ app.post('/api/articles/:article_id/comments', addComment)
 
 app.patch('/api/articles/:article_id', updateArticleById)
 
+app.delete('/api/comments/:comment_id', deleteComment)
 
 // 404 Middleware
 app.use((req, res, next) => {

--- a/app/controllers/controller.js
+++ b/app/controllers/controller.js
@@ -1,7 +1,7 @@
 const {selectTopics} = require('../models/api-topics.model')
 const {selectArticleById, selectArticles, patchArticleById} = require('../models/api-articles.model')
 const endpoints = require('../../endpoints.json')
-const { doesArticleExist, selectComments, insertComment, doesUsernameExist } = require('../models/api-comments.model')
+const { doesArticleExist, selectComments, insertComment, doesUsernameExist, removeComment } = require('../models/api-comments.model')
 
 exports.getTopics = (req, res, next) => {
     selectTopics()
@@ -91,6 +91,18 @@ exports.updateArticleById = (req, res, next) => {
     })
     .then((article) => {
         res.status(200).send({article})
+    })
+    .catch(next)
+}
+
+exports.deleteComment = (req, res, next) => {
+    const {comment_id} = req.params
+    if (isNaN(comment_id) || !Number.isInteger(Number(comment_id)) || Number(comment_id) <= 0) {
+        return next({ status: 400, message: 'Bad Request: Invalid comment id' });
+    }
+    removeComment(comment_id)
+    .then(() => {
+        res.status(204).end()
     })
     .catch(next)
 }

--- a/app/models/api-comments.model.js
+++ b/app/models/api-comments.model.js
@@ -40,3 +40,23 @@ RETURNING *;`, [username, body, article_id])
 })
 }
 
+exports.removeComment = (comment_id) => {
+    return db.query(`SELECT * FROM comments
+    WHERE comment_id = $1`, [comment_id])
+    .then((response) => {
+        if (response.rows.length === 0){
+            return Promise.reject({status: 404, message: 'No comment found'})
+        } else {
+            return db.query(`DELETE FROM comments
+            WHERE comment_id = $1
+            RETURNING *`, [comment_id])
+        }
+    })
+    // .then(() => {
+    //     return db.query(`SELECT * FROM comments
+    //     WHERE comment_id = $1`, [comment_id])
+    // })
+    // .then((response) => {
+    //     console.log(response.rows)
+    // })
+    }

--- a/endpoints.json
+++ b/endpoints.json
@@ -85,5 +85,10 @@
       "article_img_url":"https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
       "votes": 3
     }
+  },
+  "DELETE /api/comments/:comment_id": {
+    "description": "Deletes the requested comment and returns a 204",
+    "queries": [],
+    "exampleResponse": {}
   }
 }


### PR DESCRIPTION
Specifically:
-Implements logic to delete comments by comment id;
-Handles server errors (500), comment not found (404) and invalid comment id type (400)